### PR TITLE
Adds userProfileMailchimpQueue

### DIFF
--- a/mb_config.json
+++ b/mb_config.json
@@ -154,6 +154,17 @@
                     "auto_delete" : false,
                     "routing_key" : "userMailchimpStatus",
                     "binding_pattern" : "*.mailchimp.error"
+                  },
+                "userProfileMailchimpQueue" :
+                  {
+                    "__comment" : "Queue - Update user Mailchimp subscription settings.",
+                    "name" : "userProfileMailchimpQueue",
+                    "passive" : false,
+                    "durable" : true,
+                    "exclusive" : false,
+                    "auto_delete" : false,
+                    "routing_key" : "userProfileMailchimp",
+                    "binding_pattern" : "user.profile.*"
                   }
               }    
           },


### PR DESCRIPTION
Fixes #45 
- Passed JSONLint

Adds `userProfileMailchimpQueue` to support updating Mailchimp user subscription preferences when updating Drupal profile.
