### PR TITLE
Add second binding for mobileCommonsQueue

### DIFF
--- a/mb-config.inc
+++ b/mb-config.inc
@@ -122,6 +122,11 @@ putenv("MB_MOBILE_COMMONSL_CONSUME_EXCLUSIVE=0");
 putenv("MB_MOBILE_COMMONS_CONSUME_NOWAIT=0");
 
 /**
+ * Additional binding / routing for Mobile Commons queue to gather campaign signups as well
+ */
+putenv("MB_MOBILE_COMMONS_QUEUE_TOPIC_MB_TRANSACTIONAL_EXCHANGE_CAMPAIGN_PATTERN=campaign.signup.*");
+
+/**
  * RabbitMQ - Queue
  * MailChimp Campaign Signups
  */

--- a/mb_config.json
+++ b/mb_config.json
@@ -397,7 +397,7 @@
           },
         "directExternalApplicationsExchange" :
           {
-            "__comment" : "Exchange - External application messages to trigger functionality within the Message Broker system.",
+            "__comment" : "Exchange - External application messages to trigger functionality within the Message Broker system. **NOTE** needs to be renamed to topicExternalApplicationsExchange.",
             "name" : "directExternalApplicationsExchange",
             "type" : "topic",
             "passive" : false,


### PR DESCRIPTION
Fixes #53 

Adds `campaign.signup.*` binding config setting to be used with `mobileCommonsQueue`.