### PR TITLE
Revised binding_key to binding_keys

### DIFF
--- a/mb_config.json
+++ b/mb_config.json
@@ -1,432 +1,407 @@
 {
-  "rabbit" :
-  {
-    "__comment" : "General RabbitMQ configuration. Define the exchanges and related queues. Note that it possible for more than one change to send messages to a queue through the 'exclusive' setting. The hierarchy in the structure of this file is an effort to make the process easier rather a set of strict rules.",
-    "exchanges":
-      {
-        "transactionalExchange" :
-          {
-            "__comment" : "Exchange - All transactional email events from the Drupal application go to this exchange.",
-            "name" : "transactionalExchange",
-            "type" : "topic",
-            "passive" : false,
-            "durable" : true,
-            "auto_delete" : false,
-            "queues" :
-              {
-                "transactionalQueue" :
-                  {
-                    "__comment" : "Queue - Email events, queue items are used to generate single transaction request to Mandrill.",
-                    "name" : "transactionalQueue",
-                    "passive" : false,
-                    "durable" : true,
-                    "exclusive" : false,
-                    "auto_delete" : false,
-                    "routing_key" : "transactional",
-                    "binding_pattern" : "*.*.transactional",
-                    "consume" :
-                      {
-                        "tag" : "transactional",
-                        "no_local" : false,
-                        "no_ack" : false,
-                        "nowait" : false
-                      }
-                  },
-                "loggingQueue" :
-                  {
-                    "__comment" : "Queue - Mongo based logging of all transactions.",
-                    "name" : "loggingQueue",
-                    "passive" : false,
-                    "durable" : true,
-                    "exclusive" : false,
-                    "auto_delete" : false,
-                    "routing_key" : "logging",
-                    "binding_pattern" : "*.*.transactional",
-                    "consume" :
-                      {
-                        "tag" : "logging",
-                        "no_local" : false,
-                        "no_ack" : true,
-                        "exclusive" : false,
-                        "nowait" : true
-                      }
-                  },
-                "activityStatsQueue" :
-                  {
-                    "__comment" : "Queue - transactional activity to be consumed by the lobby dashboard app.",
-                    "name" : "activityStatsQueue",
-                    "passive" : false,
-                    "durable" : true,
-                    "exclusive" : false,
-                    "auto_delete" : false,
-                    "routing_key" : "activityStats",
-                    "binding_pattern" : "*.*.transactional",
-                    "consume" :
-                      {
-                        "tag" : "activityStats",
-                        "no_local" : false,
-                        "no_ack" : true,
-                        "exclusive" : false,
-                        "nowait" : true
-                      }
-                  },
-                "userRegistrationQueue" :
-                  {
-                    "__comments" : "Queue - Submit user registration details to Mailchimp.",
-                    "name" : "userRegistrationQueue",
-                    "passive" : false,
-                    "durable" : true,
-                    "exclusive" : false,
-                    "auto_delete" : false,
-                    "routing_key" : "serRegistration",
-                    "binding_pattern" : "user.registration.*"
-                  },
-                "mobileCommonsQueue" :
-                  {
-                    "__comment" : "Queue - All transactions with mobile information is submitted to Mobile Commons.",
-                    "name" : "mobileCommonsQueue",
-                    "passive" : false,
-                    "durable" : true,
-                    "exclusive" : false,
-                    "auto_delete" : false,
-                    "routing_key" : "mobileCommonsRegistration",
-                    "binding_pattern" : "user.registration.*",
-                    "consume" :
-                      {
-                        "tag" : "mobile",
-                        "no_local" : false,
-                        "no_ack" : false,
-                        "exclusive" : false,
-                        "nowait" : false
-                      }
-                  },
-                "mailchimpCampaignSignupQueue" :
-                  {
-                    "__comment" : "Queue - All member campaign activity is added to the user account on Mailchimp.",
-                    "name" : "mailchimpCampaignSignupQueue",
-                    "passive" : false,
-                    "durable" : true,
-                    "exclusive" : false,
-                    "auto_delete" : false,
-                    "routing_key" : "mailchimpCampaignSignup",
-                    "binding_pattern" : "campaign.signup.*"
-                  },
-                "userAPIRegistrationQueue" :
-                  {
-                    "__comment" : "Queue - New user registrations information is added to the mb-user database.",
-                    "name" : "userAPIRegistrationQueue",
-                    "passive" : false,
-                    "durable" : true,
-                    "exclusive" : false,
-                    "auto_delete" : false,
-                    "routing_key" : "userAPIRegistration",
-                    "binding_pattern" : "user.registration.#"
-                  },
-                "userAPICampaignActivityQueue" :
-                  {
-                    "__comment" : "Queue - All user campaign activity (signups and report backs) is added to the mb-user database.",
-                    "name" : "userAPICampaignActivityQueue",
-                    "passive" : false,
-                    "durable" : true,
-                    "exclusive" : false,
-                    "auto_delete" : false,
-                    "routing_key" : "userAPICampaignActivity",
-                    "binding_pattern" : "campaign.*.*"
-                  },
-                "userAPIProfileQueue" :
-                  {
-                    "__comment" : "Queue - Add/update/delete user profile settings in the userAPI.",
-                    "name" : "userAPIProfileQueue",
-                    "passive" : false,
-                    "durable" : true,
-                    "exclusive" : false,
-                    "auto_delete" : false,
-                    "routing_key" : "userAPIProfile",
-                    "binding_pattern" : "user.profile.*"
-                  },
-                "userMailchimpStatusQueue" :
-                  {
-                    "__comment" : "Queue - When email accounts are added or updated on Mailchimp a status is returned including any errors or issues that will prevent sending further messages to the email address. This queue logs these issues and updates the mb-user database.",
-                    "name" : "userMailchimpStatusQueue",
-                    "passive" : false,
-                    "durable" : true,
-                    "exclusive" : false,
-                    "auto_delete" : false,
-                    "routing_key" : "userMailchimpStatus",
-                    "binding_pattern" : "*.mailchimp.error"
-                  },
-                "userProfileMailchimpQueue" :
-                  {
-                    "__comment" : "Queue - Update user Mailchimp subscription settings.",
-                    "name" : "userProfileMailchimpQueue",
-                    "passive" : false,
-                    "durable" : true,
-                    "exclusive" : false,
-                    "auto_delete" : false,
-                    "routing_key" : "userProfileMailchimp",
-                    "binding_pattern" : "user.profile.*"
-                  }
-              }    
-          },
-        "directMailchimpWebhooks" :
-          {
-            "__comment" : "Exchange - Entries made by webhook activity sent by Mailchimp. Used to track user unsubscribes via Mailchimp unsubscribe links in Mailchimp generated mass mailouts.",
-            "name" : "directMailchimpWebhooks",
-            "type" : "direct",
-            "passive" : false,
-            "durable" : true,
-            "auto_delete" : false,
-            "queues" :
-              {
-                "mailchimpUnsubscribeQueue" :
-                  {
-                    "__comment" : "Queue - Webhook unsubscribe events from Mailchimp.",
-                    "name" : "mailchimpUnsubscribeQueue",
-                    "passive" : false,
-                    "durable" : true,
-                    "exclusive" : false,
-                    "auto_delete" : false,
-                    "binding_key" : "mailchimpUnsubscribe"
-                  }
-              }
-          },
-        "directUserEvent" :
-          {
-            "__comment" : "Exchange - User account events by time - birthday, 13th birthday, anniversary, etc.",
-            "name" : "directUserEvent",
-            "type" : "direct",
-            "passive" : false,
-            "durable" : true,
-            "auto_delete" : false,
-            "queues" :
-              {
-                "userEventBirthdayQueue" :
-                  {
-                    "__comment" : "Queue - Users who have a birthday today.",
-                    "name" : "userEventBirthdayQueue",
-                    "passive" : false,
-                    "durable" : false,
-                    "exclusive" : false,
-                    "auto_delete" : true,
-                    "routing_key" : "userEventBirthday",
-                    "binding_key" : "userEventBirthday"
-                  },
-                "userEvent13BirthdayQueue" :
-                  {
-                    "__comment" : "Queue - Users who turn 13 years of age and thus start to get general DoSomething.org broadcasts..",
-                    "name" : "userEvent13BirthdayQueue",
-                    "passive" : false,
-                    "durable" : false,
-                    "exclusive" : false,
-                    "auto_delete" : true,
-                    "routing_key" : "userEvent13Birthday",
-                    "binding_key" : "userEvent13Birthday"
-                  },
-                "userEventAnniversaryQueue" :
-                  {
-                    "__comment" : "Queue - User who have signed up to DoSomehting.org one year ago.",
-                    "name" : "userEventAnniversaryQueue",
-                    "passive" : false,
-                    "durable" : false,
-                    "exclusive" : false,
-                    "auto_delete" : true,
-                    "routing_key" : "userEventAnniversary",
-                    "binding_key" : "userEventAnniversary"
-                  }
-              }
-          },
-        "directUserDigestExchange" :
-          {
-            "__comment" : "Exchange - Summary email messages for allof a users campaign activity.",
-            "name" : "directUserDigestExchange",
-            "type" : "direct",
-            "passive" : false,
-            "durable" : true,
-            "auto_delete" : false,
-            "queues" :
-              {
-                "userDigestQueue" :
-                  {
-                    "__comment" : "Queue - Users that have campaign activity that could get sent a digest message.",
-                    "name" : "userDigestQueue",
-                    "passive" : false,
-                    "durable" : true,
-                    "exclusive" : false,
-                    "auto_delete" : false,
-                    "routing_key" : "userDigest",
-                    "binding_key" : "userDigest"
-                  }
-              }
-          },
-        "directUserMailchimpStatus" :
-          {
-            "__comment" : "Exchange - Error message reported by Mailchimp after batch submit. The status / subscription of the user will be updated for reference on future messaging.",
-            "name" : "directUserMailchimpStatus",
-            "type" : "direct",
-            "passive" : false,
-            "durable" : true,
-            "auto_delete" : false,
-            "queues" :
-              {
-                "userMailchimpResubscribeQueue" :
-                  {
-                    "__comment" : "Queue - Users that have campaign activity that could get sent a digest message.",
-                    "name" : "userMailchimpResubscribeQueue",
-                    "passive" : false,
-                    "durable" : true,
-                    "exclusive" : false,
-                    "auto_delete" : false,
-                    "routing_key" : "userMailchimpResubscribe",
-                    "binding_key" : "userMailchimpResubscribe"
-                  }
-              }
-          },
-        "topicEmailService" :
-          {
-            "__comment" : "Exchange - All transactions related to email. Consumers will process entries based on the email service requirments in use.",
-            "name" : "topicEmailService",
-            "type" : "topic",
-            "passive" : false,
-            "durable" : true,
-            "auto_delete" : false,
-            "queues" :
-              {
-                "mailchimpSubscriptionQueue" :
-                {
-                  "__comment" : "Queue - Add entries to Mailchimp lists with 'interest group' (group) assignments. Contents to be processed in batches.",
-                  "name" : "mailchimpSubscriptionQueue",
-                  "passive" : false,
-                  "durable" : true,
-                  "exclusive" : false,
-                  "auto_delete" : false,
-                  "binding_pattern" : "subscribe.mailchimp.*"
-                },
-                "mailchimpResubscriptionQueue" :
-                {
-                  "__comment" : "Queue - Entries that were rejected in batch submissions that require a resubscription submission as a single item.",
-                  "name" : "mailchimpResubscriptionQueue",
-                  "passive" : false,
-                  "durable" : true,
-                  "exclusive" : false,
-                  "auto_delete" : false,
-                  "binding_pattern" : "resubscribe.mailchimp.*"
-                }
-              }
-          },
-        "directUserImport" :
-          {
-            "__comment" : "Exchange - Summary email messages for allof a users campaign activity.",
-            "name" : "directUserImport",
-            "type" : "direct",
-            "passive" : false,
-            "durable" : true,
-            "auto_delete" : false,
-            "queues" :
-              {
-                "userImportQueue" :
-                  {
-                    "__comment" : "Queue - User information imported from sources outside of DoSomething.org.",
-                    "name" : "userImportQueue",
-                    "passive" : false,
-                    "durable" : false,
-                    "exclusive" : false,
-                    "auto_delete" : true,
-                    "binding_key" : "userImport",
-                    "consume" :
-                      {
-                        "tag" : "userImport",
-                        "no_local" : false,
-                        "no_ack" : false,
-                        "exclusive" : false,
-                        "nowait" : false
-                      }
-                  }
-              }
-          },
-        "directUserImportExistingLogging" :
-          {
-            "__comment" : "Exchange - Log all user import results checkoing with each service (Mailchimp, Mobile Commons and Drupal) for existing sites.",
-            "name" : "directUserImportExistingLogging",
-            "type" : "direct",
-            "passive" : false,
-            "durable" : true,
-            "auto_delete" : false,
-            "queues" :
-              {
-                "userImportExistingLoggingQueue" :
-                {
-                  "__comment" : "Queue - User information imported from sources outside of DoSomething.org.",
-                  "name" : "userImportExistingLoggingQueue",
-                  "passive" : false,
-                  "durable" : false,
-                  "exclusive" : false,
-                  "auto_delete" : false,
-                  "binding_key" : "userImportExistingLogging",
-                  "consume" :
-                    {
-                      "tag" : "userImportExistingLogging",
-                      "no_local" : false,
-                      "no_ack" : false,
-                      "exclusive" : false,
-                      "nowait" : false
+    "rabbit": {
+        "__comment": "General RabbitMQ configuration. Define the exchanges and related queues. Note that it possible for more than one change to send messages to a queue through the 'exclusive' setting. The hierarchy in the structure of this file is an effort to make the process easier rather a set of strict rules.",
+        "exchanges": {
+            "transactionalExchange": {
+                "__comment": "Exchange - All transactional email events from the Drupal application go to this exchange.",
+                "name": "transactionalExchange",
+                "type": "topic",
+                "passive": false,
+                "durable": true,
+                "auto_delete": false,
+                "queues": {
+                    "transactionalQueue": {
+                        "__comment": "Queue - Email events, queue items are used to generate single transaction request to Mandrill.",
+                        "name": "transactionalQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "routing_key": "transactional",
+                        "binding_patterns": [
+                            "*.*.transactional"
+                        ],
+                        "consume": {
+                            "tag": "transactional",
+                            "no_local": false,
+                            "no_ack": false,
+                            "nowait": false
+                        }
+                    },
+                    "loggingQueue": {
+                        "__comment": "Queue - Mongo based logging of all transactions.",
+                        "name": "loggingQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "routing_key": "logging",
+                        "binding_patterns": [
+                            "*.*.transactional"
+                        ],
+                        "consume": {
+                            "tag": "logging",
+                            "no_local": false,
+                            "no_ack": true,
+                            "exclusive": false,
+                            "nowait": true
+                        }
+                    },
+                    "activityStatsQueue": {
+                        "__comment": "Queue - transactional activity to be consumed by the lobby dashboard app.",
+                        "name": "activityStatsQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "routing_key": "activityStats",
+                        "binding_patterns": [
+                            "*.*.transactional"
+                        ],
+                        "consume": {
+                            "tag": "activityStats",
+                            "no_local": false,
+                            "no_ack": true,
+                            "exclusive": false,
+                            "nowait": true
+                        }
+                    },
+                    "userRegistrationQueue": {
+                        "__comments": "Queue - Submit user registration details to Mailchimp.",
+                        "name": "userRegistrationQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "routing_key": "serRegistration",
+                        "binding_patterns": [
+                            "user.registration.*"
+                        ]
+                    },
+                    "mobileCommonsQueue": {
+                        "__comment": "Queue - All transactions with mobile information is submitted to Mobile Commons.",
+                        "name": "mobileCommonsQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "routing_key": "mobileCommonsRegistration",
+                        "binding_patterns": [
+                            "user.registration.*",
+                            "campaign.signup.*"
+                        ],
+                        "consume": {
+                            "tag": "mobile",
+                            "no_local": false,
+                            "no_ack": false,
+                            "exclusive": false,
+                            "nowait": false
+                        }
+                    },
+                    "mailchimpCampaignSignupQueue": {
+                        "__comment": "Queue - All member campaign activity is added to the user account on Mailchimp.",
+                        "name": "mailchimpCampaignSignupQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "routing_key": "mailchimpCampaignSignup",
+                        "binding_patterns": [
+                            "campaign.signup.*"
+                        ]
+                    },
+                    "userAPIRegistrationQueue": {
+                        "__comment": "Queue - New user registrations information is added to the mb-user database.",
+                        "name": "userAPIRegistrationQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "routing_key": "userAPIRegistration",
+                        "binding_patterns": [
+                            "user.registration.#"
+                        ]
+                    },
+                    "userAPICampaignActivityQueue": {
+                        "__comment": "Queue - All user campaign activity (signups and report backs) is added to the mb-user database.",
+                        "name": "userAPICampaignActivityQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "routing_key": "userAPICampaignActivity",
+                        "binding_patterns": [
+                            "campaign.*.*"
+                        ]
+                    },
+                    "userAPIProfileQueue": {
+                        "__comment": "Queue - Add/update/delete user profile settings in the userAPI.",
+                        "name": "userAPIProfileQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "routing_key": "userAPIProfile",
+                        "binding_patterns": [
+                            "user.profile.*"
+                        ]
+                    },
+                    "userMailchimpStatusQueue": {
+                        "__comment": "Queue - When email accounts are added or updated on Mailchimp a status is returned including any errors or issues that will prevent sending further messages to the email address. This queue logs these issues and updates the mb-user database.",
+                        "name": "userMailchimpStatusQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "routing_key": "userMailchimpStatus",
+                        "binding_patterns": [
+                            "*.mailchimp.error"
+                        ]
+                    },
+                    "userProfileMailchimpQueue": {
+                        "__comment": "Queue - Update user Mailchimp subscription settings.",
+                        "name": "userProfileMailchimpQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "routing_key": "userProfileMailchimp",
+                        "binding_patterns": [
+                            "user.profile.*"
+                        ]
                     }
                 }
-              }
-          },
-        "directHeartbeatExchange" :
-          {
-            "__comment" : "Exchange - Summary email messages for allof a users campaign activity.",
-            "name" : "directHeartbeatExchange",
-            "type" : "direct",
-            "passive" : false,
-            "durable" : true,
-            "auto_delete" : false,
-            "queues" :
-              {
-                "heartbeatQueue" :
-                {
-                  "__comment" : "Queue - Heartbeat activities to monitor as it flows through the system.",
-                  "name" : "heartbeatQueue",
-                  "passive" : false,
-                  "durable" : false,
-                  "exclusive" : false,
-                  "auto_delete" : true,
-                  "binding_key" : "heartbeat"
+            },
+            "directMailchimpWebhooks": {
+                "__comment": "Exchange - Entries made by webhook activity sent by Mailchimp. Used to track user unsubscribes via Mailchimp unsubscribe links in Mailchimp generated mass mailouts.",
+                "name": "directMailchimpWebhooks",
+                "type": "direct",
+                "passive": false,
+                "durable": true,
+                "auto_delete": false,
+                "queues": {
+                    "mailchimpUnsubscribeQueue": {
+                        "__comment": "Queue - Webhook unsubscribe events from Mailchimp.",
+                        "name": "mailchimpUnsubscribeQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "binding_key": "mailchimpUnsubscribe"
+                    }
                 }
-              }
-          },
-        "directExternalApplicationsExchange" :
-          {
-            "__comment" : "Exchange - External application messages to trigger functionality within the Message Broker system. **NOTE** needs to be renamed to topicExternalApplicationsExchange.",
-            "name" : "directExternalApplicationsExchange",
-            "type" : "topic",
-            "passive" : false,
-            "durable" : true,
-            "auto_delete" : false,
-            "queues" :
-              {
-                "externalApplicationEventQueue" :
-                {
-                  "__comment" : "Queue - External Applications - User transactional. Examples user registration.",
-                  "name" : "externalApplicationEventQueue",
-                  "passive" : false,
-                  "durable" : true,
-                  "exclusive" : false,
-                  "auto_delete" : false,
-                  "binding_key" : "*.event.*"
-                },
-                "externalApplicationUserQueue" :
-                {
-                  "__comment" : "Queue - External Applications - User transactional. Examples user registration.",
-                  "name" : "externalApplicationUserQueue",
-                  "passive" : false,
-                  "durable" : true,
-                  "exclusive" : false,
-                  "auto_delete" : false,
-                  "binding_key" : "*.user.*"
+            },
+            "directUserEvent": {
+                "__comment": "Exchange - User account events by time - birthday, 13th birthday, anniversary, etc.",
+                "name": "directUserEvent",
+                "type": "direct",
+                "passive": false,
+                "durable": true,
+                "auto_delete": false,
+                "queues": {
+                    "userEventBirthdayQueue": {
+                        "__comment": "Queue - Users who have a birthday today.",
+                        "name": "userEventBirthdayQueue",
+                        "passive": false,
+                        "durable": false,
+                        "exclusive": false,
+                        "auto_delete": true,
+                        "routing_key": "userEventBirthday",
+                        "binding_key": "userEventBirthday"
+                    },
+                    "userEvent13BirthdayQueue": {
+                        "__comment": "Queue - Users who turn 13 years of age and thus start to get general DoSomething.org broadcasts..",
+                        "name": "userEvent13BirthdayQueue",
+                        "passive": false,
+                        "durable": false,
+                        "exclusive": false,
+                        "auto_delete": true,
+                        "routing_key": "userEvent13Birthday",
+                        "binding_key": "userEvent13Birthday"
+                    },
+                    "userEventAnniversaryQueue": {
+                        "__comment": "Queue - User who have signed up to DoSomehting.org one year ago.",
+                        "name": "userEventAnniversaryQueue",
+                        "passive": false,
+                        "durable": false,
+                        "exclusive": false,
+                        "auto_delete": true,
+                        "routing_key": "userEventAnniversary",
+                        "binding_key": "userEventAnniversary"
+                    }
                 }
-              }
-          }
-      }
-  }
+            },
+            "directUserDigestExchange": {
+                "__comment": "Exchange - Summary email messages for allof a users campaign activity.",
+                "name": "directUserDigestExchange",
+                "type": "direct",
+                "passive": false,
+                "durable": true,
+                "auto_delete": false,
+                "queues": {
+                    "userDigestQueue": {
+                        "__comment": "Queue - Users that have campaign activity that could get sent a digest message.",
+                        "name": "userDigestQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "routing_key": "userDigest",
+                        "binding_key": "userDigest"
+                    }
+                }
+            },
+            "directUserMailchimpStatus": {
+                "__comment": "Exchange - Error message reported by Mailchimp after batch submit. The status / subscription of the user will be updated for reference on future messaging.",
+                "name": "directUserMailchimpStatus",
+                "type": "direct",
+                "passive": false,
+                "durable": true,
+                "auto_delete": false,
+                "queues": {
+                    "userMailchimpResubscribeQueue": {
+                        "__comment": "Queue - Users that have campaign activity that could get sent a digest message.",
+                        "name": "userMailchimpResubscribeQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "routing_key": "userMailchimpResubscribe",
+                        "binding_key": "userMailchimpResubscribe"
+                    }
+                }
+            },
+            "topicEmailService": {
+                "__comment": "Exchange - All transactions related to email. Consumers will process entries based on the email service requirments in use.",
+                "name": "topicEmailService",
+                "type": "topic",
+                "passive": false,
+                "durable": true,
+                "auto_delete": false,
+                "queues": {
+                    "mailchimpSubscriptionQueue": {
+                        "__comment": "Queue - Add entries to Mailchimp lists with 'interest group' (group) assignments. Contents to be processed in batches.",
+                        "name": "mailchimpSubscriptionQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "binding_patterns": [
+                            "subscribe.mailchimp.*"
+                        ]
+                    },
+                    "mailchimpResubscriptionQueue": {
+                        "__comment": "Queue - Entries that were rejected in batch submissions that require a resubscription submission as a single item.",
+                        "name": "mailchimpResubscriptionQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "binding_patterns": [
+                            "resubscribe.mailchimp.*"
+                        ]
+                    }
+                }
+            },
+            "directUserImport": {
+                "__comment": "Exchange - Summary email messages for allof a users campaign activity.",
+                "name": "directUserImport",
+                "type": "direct",
+                "passive": false,
+                "durable": true,
+                "auto_delete": false,
+                "queues": {
+                    "userImportQueue": {
+                        "__comment": "Queue - User information imported from sources outside of DoSomething.org.",
+                        "name": "userImportQueue",
+                        "passive": false,
+                        "durable": false,
+                        "exclusive": false,
+                        "auto_delete": true,
+                        "binding_key": "userImport",
+                        "consume": {
+                            "tag": "userImport",
+                            "no_local": false,
+                            "no_ack": false,
+                            "exclusive": false,
+                            "nowait": false
+                        }
+                    }
+                }
+            },
+            "directUserImportExistingLogging": {
+                "__comment": "Exchange - Log all user import results checkoing with each service (Mailchimp, Mobile Commons and Drupal) for existing sites.",
+                "name": "directUserImportExistingLogging",
+                "type": "direct",
+                "passive": false,
+                "durable": true,
+                "auto_delete": false,
+                "queues": {
+                    "userImportExistingLoggingQueue": {
+                        "__comment": "Queue - User information imported from sources outside of DoSomething.org.",
+                        "name": "userImportExistingLoggingQueue",
+                        "passive": false,
+                        "durable": false,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "binding_key": "userImportExistingLogging",
+                        "consume": {
+                            "tag": "userImportExistingLogging",
+                            "no_local": false,
+                            "no_ack": false,
+                            "exclusive": false,
+                            "nowait": false
+                        }
+                    }
+                }
+            },
+            "directHeartbeatExchange": {
+                "__comment": "Exchange - Summary email messages for allof a users campaign activity.",
+                "name": "directHeartbeatExchange",
+                "type": "direct",
+                "passive": false,
+                "durable": true,
+                "auto_delete": false,
+                "queues": {
+                    "heartbeatQueue": {
+                        "__comment": "Queue - Heartbeat activities to monitor as it flows through the system.",
+                        "name": "heartbeatQueue",
+                        "passive": false,
+                        "durable": false,
+                        "exclusive": false,
+                        "auto_delete": true,
+                        "binding_key": "heartbeat"
+                    }
+                }
+            },
+            "directExternalApplicationsExchange": {
+                "__comment": "Exchange - External application messages to trigger functionality within the Message Broker system. **NOTE** needs to be renamed to topicExternalApplicationsExchange.",
+                "name": "directExternalApplicationsExchange",
+                "type": "topic",
+                "passive": false,
+                "durable": true,
+                "auto_delete": false,
+                "queues": {
+                    "externalApplicationEventQueue": {
+                        "__comment": "Queue - External Applications - User transactional. Examples user registration.",
+                        "name": "externalApplicationEventQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "binding_key": "*.event.*"
+                    },
+                    "externalApplicationUserQueue": {
+                        "__comment": "Queue - External Applications - User transactional. Examples user registration.",
+                        "name": "externalApplicationUserQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "binding_key": "*.user.*"
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes #54 

Revised to support `binding_keys` as an array in replacement of `binding_key` as a single string.

**Note**: This file needs allot of refactoring before it can replace mb-config.inc` in production.