### PR TITLE
Add Image Processing Queue settings

### DIFF
--- a/mb-config.inc
+++ b/mb-config.inc
@@ -168,6 +168,19 @@ putenv("MB_USER_API_CAMPAIGN_ACTIVITY_QUEUE_TOPIC_MB_TRANSACTIONAL_EXCHANGE_PATT
 
 /**
  * RabbitMQ - Queue
+ * Image Processing - Process images to generate cache files for defined image styles. An example is Drupal report back images which have image styles of various sizes.
+ */
+putenv("MB_IMAGE_PROCESSING_ROUTING_KEY=imageProcessing");
+
+putenv("MB_IMAGE_PROCESSING_QUEUE=imageProcessingQueue");
+putenv("MB_IMAGE_PROCESSING_QUEUE_PASSIVE=0");
+putenv("MB_IMAGE_PROCESSING_QUEUE_DURABLE=1");
+putenv("MB_IMAGE_PROCESSING_QUEUE_EXCLUSIVE=0");
+putenv("MB_IMAGE_PROCESSING_QUEUE_AUTO_DELETE=0");
+putenv("MB_IMAGE_PROCESSING_QUEUE_TOPIC_MB_TRANSACTIONAL_EXCHANGE_PATTERN=campaign.report_back.transactional");
+
+/**
+ * RabbitMQ - Queue
  * userMailchimpStatusQueue
  */
 putenv("MB_USER_MAILCHIMP_STATUS_ROUTING_KEY=user.mailchimp.error");
@@ -497,4 +510,4 @@ putenv("SUBSCRIPTIONS_URL=subscriptions.dosomething.org");
 putenv("SUBSCRIPTIONS_PORT=");
 
 // Toggle in dev / production to control StatHat collection
-putenv("USE_STAT_TRACKING=1");
+putenv("USE_STAT_TRACKING=0");

--- a/mb-config.inc
+++ b/mb-config.inc
@@ -510,4 +510,4 @@ putenv("SUBSCRIPTIONS_URL=subscriptions.dosomething.org");
 putenv("SUBSCRIPTIONS_PORT=");
 
 // Toggle in dev / production to control StatHat collection
-putenv("USE_STAT_TRACKING=0");
+putenv("USE_STAT_TRACKING=1");

--- a/mb_config.json
+++ b/mb_config.json
@@ -134,6 +134,18 @@
                             "campaign.*.*"
                         ]
                     },
+                    "imageProcessingQueue": {
+                        "__comment": "Queue - Process images to generate cache files for defined image styles. An example is Drupal report back images which have image styles of various sizes.",
+                        "name": "imageProcessingQueue",
+                        "passive": false,
+                        "durable": true,
+                        "exclusive": false,
+                        "auto_delete": false,
+                        "routing_key": "imageProcessing",
+                        "binding_patterns": [
+                            "campaign.report_back.transactional"
+                        ]
+                    },
                     "userAPIProfileQueue": {
                         "__comment": "Queue - Add/update/delete user profile settings in the userAPI.",
                         "name": "userAPIProfileQueue",


### PR DESCRIPTION
Add support for `imageProcessingQueue`. The Drupal app will be the producer and `mbc-image-processing` will be the consumer.

**Related Issue**:
https://github.com/DoSomething/dosomething/issues/4105
