### PR TITLE
Deprecate messagingGroupsQueue

### DIFF
--- a/mb_config.json
+++ b/mb_config.json
@@ -67,27 +67,6 @@
               "nowait": false
             }
           },
-          "messagingGroupsQueue": {
-            "__comment": "Queue - Manage messaging groups on Mobile Commons.",
-            "name": "messagingGroupsQueue",
-            "passive": false,
-            "durable": true,
-            "exclusive": false,
-            "auto_delete": false,
-            "routing_key": "messagingGroups",
-            "binding_patterns": [
-              "campaign.report_back.transactional",
-              "campaign.signup.*",
-              "messaging_groups_direct"
-            ],
-            "consume": {
-              "tag": "messagingGroups",
-              "no_local": false,
-              "no_ack": false,
-              "exclusive": false,
-              "nowait": false
-            }
-          },
           "dispatchDelayedTextsQueue": {
             "__comment": "Queue - dispatch delayed texts.",
             "name": "dispatchDelayedTextsQueue",


### PR DESCRIPTION
We're migrated from Mobile Commons to Twilio.